### PR TITLE
Fix typo in email address

### DIFF
--- a/StackSplit/SL_mod/SL_1.0.5_mod/getFileAndEQseconds_SS.m
+++ b/StackSplit/SL_mod/SL_1.0.5_mod/getFileAndEQseconds_SS.m
@@ -12,7 +12,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 
 %==========================================================================
 % Yvonne Fröhlich (YF), Karlsruhe Institute of Technology (KIT), 
-% Email: yvonne.froelich@kit.edu
+% Email: yvonne.froehlich@kit.edu
 % July-December 2021
 %
 % modifications to fix extraction of start time by SplitLab 

--- a/StackSplit/SL_mod/SL_1.2.1_mod/getFileAndEQseconds_SS.m
+++ b/StackSplit/SL_mod/SL_1.2.1_mod/getFileAndEQseconds_SS.m
@@ -14,7 +14,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 
 %==========================================================================
 % Yvonne Fröhlich (YF), Karlsruhe Institute of Technology (KIT), 
-% Email: yvonne.froelich@kit.edu
+% Email: yvonne.froehlich@kit.edu
 % July-December 2021
 %
 % modifications to fix extraction of start time by SplitLab 


### PR DESCRIPTION
This PR fixes a typo in the email address in the modified SplitLab function ``getFileAndEQseconds.m`` for both SplitLab versions 1.0.5 and 1.2.1.