### PR TITLE
Fix component order of exported seismograms

### DIFF
--- a/StackSplit/SL_mod/SL_1.0.5_mod/seisfigbuttons_SS.m
+++ b/StackSplit/SL_mod/SL_1.0.5_mod/seisfigbuttons_SS.m
@@ -239,10 +239,10 @@ Amp    = Amp(:,window);
 time   = time(window);
 
 
-if thiseq.system=='ENV'
-    cname ='ENZ';
-elseif thiseq.system=='LTQ'
-    cname ='LTQ';
+if strcmp(thiseq.system,'ENV')
+    cname = 'ENZ';
+elseif strcmp(thiseq.system,'LTQ')
+    cname = 'QTL';
 end
 if ~isfield(thiseq,'a')
     A = -12345;

--- a/StackSplit/SL_mod/SL_1.2.1_mod/seisfigbuttons_SS.m
+++ b/StackSplit/SL_mod/SL_1.2.1_mod/seisfigbuttons_SS.m
@@ -239,10 +239,10 @@ Amp    = Amp(:,window);
 time   = time(window);
 
 
-if thiseq.system=='ENV'
-    cname ='ENZ';
-elseif thiseq.system=='LTQ'
-    cname ='LTQ';
+if strcmp(thiseq.system,'ENV')
+    cname = 'ENZ';
+elseif strcmp(thiseq.system,'LTQ')
+    cname = 'QTL';
 end
 if ~isfield(thiseq,'a')
     A = -12345;


### PR DESCRIPTION
 This PR fixes an error in the order of the L, Q, T components when saving the traces which are currently displayed in the Seismogram Viewer as new SAC files by the _SplitLab_ function `seisfigbuttons.m` for both _SplitLab_ versions 1.0.5 and 1.2.1.

 The export order of the traces is based on the display order in the Seismogram Viewer. For the ray coordinate system this is `Q T L` (top to bottom).  However, the string used and split into single characters to set SAC header and file name is `cname = 'LTQ'` (left to right).  This leads to mixed up L and Q components of the exported traces. To avoid this `cname` was changed to `cname = 'QTL'`.
