### PR TITLE
fix vline in exported STACK diagplot

### DIFF
--- a/StackSplit/SS_stack_Esurf.m
+++ b/StackSplit/SS_stack_Esurf.m
@@ -432,8 +432,12 @@ contour(ts, ps, STACKsurf, nb_contours);
 
 set(hcon,'FaceColor',[1 1 1]*.90,'EdgeColor','k','linestyle','-','linewidth',1)
 
-line([0 maxtime], [singlephiSTACK(2) singlephiSTACK(2)],'Color',[0 0 1])
-line([singledtSTACK(2) singledtSTACK(2)],[-90 90],'Color',[0 0 1])
+% horizontal line plotted twice for sake of safety
+line([0 maxtime], [singlephiSTACK(2) singlephiSTACK(2)], 'Color',[0 0 1])
+line([0 maxtime], [singlephiSTACK(2) singlephiSTACK(2)], 'Color',[0 0 1])
+% vertical line plotted twice to be also visible in exported diagnostic plot
+line([singledtSTACK(2) singledtSTACK(2)], [-90 90], 'Color',[0 0 1]) 
+line([singledtSTACK(2) singledtSTACK(2)], [-90 90], 'Color',[0 0 1])
 
 colormap(gray)
 


### PR DESCRIPTION
This PR addresses an issue regarding the exported diagnostic plot of _StackSplit_. This is only relevant for the error surface stacking options (no weight, WS, RH).

After stacking the error surfaces a contour plot is provided. It is shown in the main _StackSplit_ window und contains horizontal and vertical blue lines indicating the best solution. However, in the exported diagnostic plot (both png and pdf format) the vertical line is missing in the contour plot. The horizontal line is visible. This holds for all three error surface stacking options. Only the last plotted line of these two lines is affected by this issue.

Here this is simply fixed by plotting the vertical line twice in the _StackSplit_ function `SS_stack_Esurf.m`. For the sake of safety also the horizontal line is plot twice.
