### PR TITLE
Add reference to publication Fröhlich et al. (2022) in modified SL function

### DIFF
--- a/StackSplit/SL_mod/SL_1.0.5_mod/getFileAndEQseconds_SS.m
+++ b/StackSplit/SL_mod/SL_1.0.5_mod/getFileAndEQseconds_SS.m
@@ -18,6 +18,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 

--- a/StackSplit/SL_mod/SL_1.0.5_mod/getFileAndEQseconds_SS.m
+++ b/StackSplit/SL_mod/SL_1.0.5_mod/getFileAndEQseconds_SS.m
@@ -18,7 +18,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================

--- a/StackSplit/SL_mod/SL_1.2.1_mod/getFileAndEQseconds_SS.m
+++ b/StackSplit/SL_mod/SL_1.2.1_mod/getFileAndEQseconds_SS.m
@@ -20,6 +20,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 

--- a/StackSplit/SL_mod/SL_1.2.1_mod/getFileAndEQseconds_SS.m
+++ b/StackSplit/SL_mod/SL_1.2.1_mod/getFileAndEQseconds_SS.m
@@ -20,7 +20,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================


### PR DESCRIPTION
This PR adds the reference to the publication Fröhlich, Grund, Ritter (2022) Annals of Geophysics to the scripts of the modified SplitLab function `getFileAndEQseconds_SS.m`.