### PR TITLE
Use "exist" with two input arguments

### DIFF
--- a/StackSplit/SS_saveresults.m
+++ b/StackSplit/SS_saveresults.m
@@ -94,7 +94,7 @@ if exist('h','var') && sum([h.check(1).Value h.check(2).Value h.check(3).Value])
 
     fname = fullfile(config.savedir,['splitresultsSTACK_' config.project(1:end-4) '.txt' ]);
 
-    xst   = exist(fname);
+    xst   = exist(fname,'file');
     fid   = fopen(fname,'a+');
     if ~xst
         fprintf(fid,'Stacked surface (ME or EV) splitting results, methods: nw (no weight), WS (Wolfe & Silver, 1998), RH (Restivo & Helffrich, 1999)');
@@ -256,7 +256,7 @@ else
     %....................................
     fname = fullfile(config.savedir,['splitresultsSIMW_' config.project(1:end-4) '.txt' ]);
 
-    xst   = exist(fname);
+    xst   = exist(fname,'file');
     fid   = fopen(fname,'a+');
     if ~xst
         fprintf(fid,'Splitting results from SIMW analysis' );


### PR DESCRIPTION
MATLAB recommends to use `exist` with two input arguments:
![matlab_warning_exist_2args](https://github.com/michaelgrund/stacksplit/assets/94163266/db8192e8-2b27-4b79-ae0f-d8e52a1df6ef)
This PR aims to update StackSplit regarding this.