### PR TITLE
Update to R2024a: Use "isscalar" instead of length comparison

### DIFF
--- a/StackSplit/SS_disp_Esurf_single.m
+++ b/StackSplit/SS_disp_Esurf_single.m
@@ -46,8 +46,7 @@ maxtime=h.EMAP_maxtime; % maximum time displayed in grid
 find_res=h.data;
 
 %=================================================================================
-% if length(index)==1  % YF 2024-01-07
-if isscalar(index)
+if isscalar(index)  % YF 2024-01-07
 
     cla reset
 

--- a/StackSplit/SS_disp_Esurf_single.m
+++ b/StackSplit/SS_disp_Esurf_single.m
@@ -46,7 +46,7 @@ maxtime=h.EMAP_maxtime; % maximum time displayed in grid
 find_res=h.data;
 
 %=================================================================================
-% if length(index)==1  % YF 2024/01/07
+% if length(index)==1  % YF 2024-01-07
 if isscalar(index)
 
     cla reset

--- a/StackSplit/SS_disp_Esurf_single.m
+++ b/StackSplit/SS_disp_Esurf_single.m
@@ -46,7 +46,8 @@ maxtime=h.EMAP_maxtime; % maximum time displayed in grid
 find_res=h.data;
 
 %=================================================================================
-if length(index)==1
+% if length(index)==1  % YF 2024/01/07
+if isscalar(index)
 
     cla reset
 

--- a/StackSplit/SS_prep_SIMW.m
+++ b/StackSplit/SS_prep_SIMW.m
@@ -75,8 +75,7 @@ index=get(h.list,'value');
 %=============================================================================
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% if length(index)==1 % one single event  % YF 2024-01-07
-if isscalar(index) % one single event
+if isscalar(index) % one single event  % YF 2024-01-07
 
     tapdesign=tukeywin(length(find_res(index).results.Qcut),h.usetap);
 

--- a/StackSplit/SS_prep_SIMW.m
+++ b/StackSplit/SS_prep_SIMW.m
@@ -75,7 +75,7 @@ index=get(h.list,'value');
 %=============================================================================
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% if length(index)==1 % one single event  % YF 2024/01/07
+% if length(index)==1 % one single event  % YF 2024-01-07
 if isscalar(index) % one single event
 
     tapdesign=tukeywin(length(find_res(index).results.Qcut),h.usetap);

--- a/StackSplit/SS_prep_SIMW.m
+++ b/StackSplit/SS_prep_SIMW.m
@@ -75,7 +75,8 @@ index=get(h.list,'value');
 %=============================================================================
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-if length(index)==1 % one single event
+% if length(index)==1 % one single event  % YF 2024/01/07
+if isscalar(index) % one single event
 
     tapdesign=tukeywin(length(find_res(index).results.Qcut),h.usetap);
 

--- a/StackSplit/install_StackSplit.m
+++ b/StackSplit/install_StackSplit.m
@@ -100,6 +100,11 @@ function install_StackSplit()
 %                => modifications to fix extraction of start time by SplitLab
 %                (unconsidered milliseconds or seconds of start time)
 %
+% - v3.1 (2024): Yvonne Fröhlich
+%                ORCID: 0000-0002-8566-0619
+%                Up on MATLAB R2024a, recommendation "To improve
+%                performance, use isscalar instead of length comparison."
+%                => Update length(xyz)==1 to isscalar(xyz)
 %==========================================================================
 
 %==================================================================================================================================

--- a/StackSplit/install_StackSplit.m
+++ b/StackSplit/install_StackSplit.m
@@ -147,7 +147,7 @@ dir_orifiles=dir(['splitlab' filesuffix '.m']);
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)   % YF 2024-01-11
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)  % YF 2024-01-11
     disp(' ')
     disp('Installation aborted. Found installed version of StackSplit!')
     errordlg('StackSplit was already installed on your system!')

--- a/StackSplit/install_StackSplit.m
+++ b/StackSplit/install_StackSplit.m
@@ -147,16 +147,14 @@ dir_orifiles=dir(['splitlab' filesuffix '.m']);
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1 && ~isempty(dir_orifiles)  % YF 2024-01-11
-if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)   % YF 2024-01-11
     disp(' ')
     disp('Installation aborted. Found installed version of StackSplit!')
     errordlg('StackSplit was already installed on your system!')
     return
 end
 
-% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024-01-11
-if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)  % YF 2024-01-11
     pathSS=[folderSL '/StackSplit'];
     disp(' ')
     disp('Start installation of StackSplit...')
@@ -264,8 +262,7 @@ end
 
 dir_SWS=dir('*WaveSplitting');
 
-% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024-01-11
-if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
+if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)  % YF 2024-01-11
     cd(dir_SWS.name)
     pathSWS=pwd;
 else
@@ -333,8 +330,7 @@ cd(folderSL)
 
 dir_TOOL=dir('*Tools');
 
-% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024-01-11
-if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
+if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)  % YF 2024-01-11
     cd(dir_TOOL.name)
     pathTOOL=pwd;
 else
@@ -375,8 +371,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
-% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024-01-11
-if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
+if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)  % YF 2024-01-11
     cd(dir_priv.name)
     pathpriv=pwd;
 else

--- a/StackSplit/install_StackSplit.m
+++ b/StackSplit/install_StackSplit.m
@@ -147,7 +147,7 @@ dir_orifiles=dir(['splitlab' filesuffix '.m']);
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1 && ~isempty(dir_orifiles)  % YF 2024/01/11
+% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1 && ~isempty(dir_orifiles)  % YF 2024-01-11
 if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)
     disp(' ')
     disp('Installation aborted. Found installed version of StackSplit!')
@@ -155,7 +155,7 @@ if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_or
     return
 end
 
-% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024/01/11
+% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024-01-11
 if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
     pathSS=[folderSL '/StackSplit'];
     disp(' ')
@@ -264,7 +264,7 @@ end
 
 dir_SWS=dir('*WaveSplitting');
 
-% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024/01/11
+% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024-01-11
 if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
     cd(dir_SWS.name)
     pathSWS=pwd;
@@ -333,7 +333,7 @@ cd(folderSL)
 
 dir_TOOL=dir('*Tools');
 
-% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024/01/11
+% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024-01-11
 if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
     cd(dir_TOOL.name)
     pathTOOL=pwd;
@@ -375,7 +375,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
-% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024/01/11
+% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024-01-11
 if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
     cd(dir_priv.name)
     pathpriv=pwd;

--- a/StackSplit/install_StackSplit.m
+++ b/StackSplit/install_StackSplit.m
@@ -142,14 +142,14 @@ dir_orifiles=dir(['splitlab' filesuffix '.m']);
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1 && ~isempty(dir_orifiles)
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)
     disp(' ')
     disp('Installation aborted. Found installed version of StackSplit!')
     errordlg('StackSplit was already installed on your system!')
     return
 end
 
-if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
     pathSS=[folderSL '/StackSplit'];
     disp(' ')
     disp('Start installation of StackSplit...')
@@ -257,7 +257,7 @@ end
 
 dir_SWS=dir('*WaveSplitting');
 
-if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1
+if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
     cd(dir_SWS.name)
     pathSWS=pwd;
 else
@@ -325,7 +325,7 @@ cd(folderSL)
 
 dir_TOOL=dir('*Tools');
 
-if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1
+if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
     cd(dir_TOOL.name)
     pathTOOL=pwd;
 else
@@ -366,7 +366,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
-if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1
+if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
     cd(dir_priv.name)
     pathpriv=pwd;
 else

--- a/StackSplit/install_StackSplit.m
+++ b/StackSplit/install_StackSplit.m
@@ -142,6 +142,7 @@ dir_orifiles=dir(['splitlab' filesuffix '.m']);
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
+% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1 && ~isempty(dir_orifiles)  % YF 2024/01/11
 if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_orifiles)
     disp(' ')
     disp('Installation aborted. Found installed version of StackSplit!')
@@ -149,6 +150,7 @@ if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS) && ~isempty(dir_or
     return
 end
 
+% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024/01/11
 if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
     pathSS=[folderSL '/StackSplit'];
     disp(' ')
@@ -257,6 +259,7 @@ end
 
 dir_SWS=dir('*WaveSplitting');
 
+% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024/01/11
 if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
     cd(dir_SWS.name)
     pathSWS=pwd;
@@ -325,6 +328,7 @@ cd(folderSL)
 
 dir_TOOL=dir('*Tools');
 
+% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024/01/11
 if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
     cd(dir_TOOL.name)
     pathTOOL=pwd;
@@ -366,6 +370,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
+% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024/01/11
 if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
     cd(dir_priv.name)
     pathpriv=pwd;

--- a/StackSplit/uninstall_StackSplit.m
+++ b/StackSplit/uninstall_StackSplit.m
@@ -79,6 +79,7 @@ end
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
+% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024/01/11
 if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
     disp('Uninstall StackSplit...')
 else
@@ -122,7 +123,10 @@ rmdir(dirSS.name,'s')
 % check if original SL function (*_ori.m) is available
 dir_orifiles=dir(['*' filesuffix '.m']);
 
-if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
+% if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
+%    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])  % YF 2024/01/11
+if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
+    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
 
     % first delete the current StackSplit version of the function with correct name
     dir_splitlab=dir('splitlab.m');
@@ -149,6 +153,7 @@ end
 
 dir_TOOL=dir('*Tools');
 
+% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024/01/11
 if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
     cd(dir_TOOL.name)
 else
@@ -226,6 +231,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
+% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024/01/11
 if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
     cd(dir_priv.name)
 else
@@ -235,6 +241,8 @@ end
 % check if original SL function (*_ori.m) is available
 dir_orifiles=dir(['*' filesuffix '.m']);
 
+% if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
+%    strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])  % YF 2024/01/11
 if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
     strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])
 
@@ -266,6 +274,7 @@ cd(folderSL)
 
 dir_SWS=dir('*WaveSplitting');
 
+% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024/01/11
 if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
     cd(dir_SWS.name)
 else

--- a/StackSplit/uninstall_StackSplit.m
+++ b/StackSplit/uninstall_StackSplit.m
@@ -84,8 +84,7 @@ end
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024-01-11
-if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)  % YF 2024-01-11
     disp('Uninstall StackSplit...')
 else
     errordlg('Missing StackSplit folder! Uninstallation aborted!')
@@ -128,10 +127,8 @@ rmdir(dirSS.name,'s')
 % check if original SL function (*_ori.m) is available
 dir_orifiles=dir(['*' filesuffix '.m']);
 
-% if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
-%    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])  % YF 2024-01-11
 if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
-    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
+    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])  % YF 2024-01-11
 
     % first delete the current StackSplit version of the function with correct name
     dir_splitlab=dir('splitlab.m');
@@ -158,8 +155,7 @@ end
 
 dir_TOOL=dir('*Tools');
 
-% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024-01-11
-if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
+if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)  % YF 2024-01-11
     cd(dir_TOOL.name)
 else
     errordlg('Missing subfolder Tools! Uninstallation aborted!')
@@ -236,8 +232,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
-% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024-01-11
-if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
+if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)  % YF 2024-01-11
     cd(dir_priv.name)
 else
     errordlg('Missing subfolder private! Uninstallation aborted!')
@@ -246,10 +241,8 @@ end
 % check if original SL function (*_ori.m) is available
 dir_orifiles=dir(['*' filesuffix '.m']);
 
-% if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
-%    strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])  % YF 2024-01-11
 if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
-    strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])
+    strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])  % YF 2024-01-11
 
     % first delete the current StackSplit version of the function with correct name
     dir_seisfig=dir('seisfigbuttons.m');
@@ -279,8 +272,7 @@ cd(folderSL)
 
 dir_SWS=dir('*WaveSplitting');
 
-% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024-01-11
-if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
+if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)  % YF 2024-01-11
     cd(dir_SWS.name)
 else
     errordlg('Missing subfolder ShearWaveSplitting! Uninstallation aborted!')

--- a/StackSplit/uninstall_StackSplit.m
+++ b/StackSplit/uninstall_StackSplit.m
@@ -56,6 +56,11 @@ function uninstall_StackSplit()
 %                => modifications to fix extraction of start time by SplitLab
 %                (unconsidered milliseconds or seconds of start time)
 %
+% - v3.1 (2024): Yvonne Fröhlich
+%                ORCID: 0000-0002-8566-0619
+%                Up on MATLAB R2024a, recommendation "To improve
+%                performance, use isscalar instead of length comparison."
+%                => Update length(xyz)==1 to isscalar(xyz)
 %==========================================================================
 
 %==================================================================================================================================

--- a/StackSplit/uninstall_StackSplit.m
+++ b/StackSplit/uninstall_StackSplit.m
@@ -84,7 +84,7 @@ end
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024/01/11
+% if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1  % YF 2024-01-11
 if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
     disp('Uninstall StackSplit...')
 else
@@ -129,7 +129,7 @@ rmdir(dirSS.name,'s')
 dir_orifiles=dir(['*' filesuffix '.m']);
 
 % if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
-%    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])  % YF 2024/01/11
+%    strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])  % YF 2024-01-11
 if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
     strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
 
@@ -158,7 +158,7 @@ end
 
 dir_TOOL=dir('*Tools');
 
-% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024/01/11
+% if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1  % YF 2024-01-11
 if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
     cd(dir_TOOL.name)
 else
@@ -236,7 +236,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
-% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024/01/11
+% if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1  % YF 2024-01-11
 if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
     cd(dir_priv.name)
 else
@@ -247,7 +247,7 @@ end
 dir_orifiles=dir(['*' filesuffix '.m']);
 
 % if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
-%    strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])  % YF 2024/01/11
+%    strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])  % YF 2024-01-11
 if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
     strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])
 
@@ -279,7 +279,7 @@ cd(folderSL)
 
 dir_SWS=dir('*WaveSplitting');
 
-% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024/01/11
+% if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1  % YF 2024-01-11
 if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
     cd(dir_SWS.name)
 else

--- a/StackSplit/uninstall_StackSplit.m
+++ b/StackSplit/uninstall_StackSplit.m
@@ -79,7 +79,7 @@ end
 % check for unzipped StackSplit folder
 dirSS=dir('StackSpl*');
 
-if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1
+if ~isempty(dirSS) && isfolder(dirSS.name) && isscalar(dirSS)
     disp('Uninstall StackSplit...')
 else
     errordlg('Missing StackSplit folder! Uninstallation aborted!')
@@ -122,7 +122,7 @@ rmdir(dirSS.name,'s')
 % check if original SL function (*_ori.m) is available
 dir_orifiles=dir(['*' filesuffix '.m']);
 
-if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
+if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
 
     % first delete the current StackSplit version of the function with correct name
     dir_splitlab=dir('splitlab.m');
@@ -149,7 +149,7 @@ end
 
 dir_TOOL=dir('*Tools');
 
-if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1
+if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && isscalar(dir_TOOL)
     cd(dir_TOOL.name)
 else
     errordlg('Missing subfolder Tools! Uninstallation aborted!')
@@ -226,7 +226,7 @@ cd(folderSL)
 
 dir_priv=dir('*private');
 
-if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1
+if ~isempty(dir_priv) && isfolder(dir_priv.name) && isscalar(dir_priv)
     cd(dir_priv.name)
 else
     errordlg('Missing subfolder private! Uninstallation aborted!')
@@ -235,7 +235,7 @@ end
 % check if original SL function (*_ori.m) is available
 dir_orifiles=dir(['*' filesuffix '.m']);
 
-if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
+if ~isempty(dir_orifiles) && isscalar(dir_orifiles) && ...
     strcmp(dir_orifiles.name,['seisfigbuttons' filesuffix '.m'])
 
     % first delete the current StackSplit version of the function with correct name
@@ -266,7 +266,7 @@ cd(folderSL)
 
 dir_SWS=dir('*WaveSplitting');
 
-if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1
+if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && isscalar(dir_SWS)
     cd(dir_SWS.name)
 else
     errordlg('Missing subfolder ShearWaveSplitting! Uninstallation aborted!')


### PR DESCRIPTION
Upon R2024a (pre-release) MATLAB suggests:
> To improve performance, use `isscalar` instead of length comparison.

when the queries contain
```matlab
length(xyz)==1
```
**Documentation**: https://de.mathworks.com/help/matlab/ref/isscalar.html; Introduced before R2006a

**Affected functions**: Output of `grep "length.*==1" *`:

- [x] `install_StackSplit.m`
```
install_StackSplit.m:if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1 && ~isempty(dir_orifiles)
install_StackSplit.m:if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1
install_StackSplit.m:if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1
install_StackSplit.m:if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1
install_StackSplit.m:if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1
```

- [x] `uninstall_StackSplit.m`
```
uninstall_StackSplit.m:if ~isempty(dirSS) && isfolder(dirSS.name) && length(dirSS)==1
uninstall_StackSplit.m:if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && strcmp(dir_orifiles.name,['splitlab' filesuffix '.m'])
uninstall_StackSplit.m:if ~isempty(dir_TOOL) && isfolder(dir_TOOL.name) && length(dir_TOOL)==1
uninstall_StackSplit.m:if ~isempty(dir_priv) && isfolder(dir_priv.name) && length(dir_priv)==1
uninstall_StackSplit.m:if ~isempty(dir_orifiles) && length(dir_orifiles)==1 && ...
uninstall_StackSplit.m:if ~isempty(dir_SWS) && isfolder(dir_SWS.name) && length(dir_SWS)==1
```

- [x] rest
```
SS_disp_Esurf_single.m:if length(index)==1
SS_prep_SIMW.m:if length(index)==1 % one single event
```

**Testing**
- Windows R2024a pre-release: Done | So far no issues faced
- Linux R2023b (R2024a pre-release license): Done | So far no issues faced