### PR TITLE
README: Convert list of stacking methods into a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ Which stacking methods are available?
 
 StackSplit grants easy access to four stacking schemes with which single SWS measurements made with SplitLab can be processed:
 
-1. **WS**: stacking of error surfaces, normalized on the minimum/maximum (depending on input) of each single surface ([**_Wolfe & Silver, 1998_**](https://doi.org/10.1029/97JB02023))
-
-2. **RH**: modified WS method with weight depending on the SNR of each measurement and normalization regarding the available backazimuth directions ([**_Restivo & Helffrich, 1999_**](https://doi.org/10.1046/j.1365-246x.1999.00845.x))
-
-3. **no weight**: stacking of error surfaces without weighting following the PhD thesis of [**_Wüstefeld (2007)_**](http://splitting.gm.univ-montp2.fr/)
-
-4. **SIMW**: simultaneous inversion of multiple waveforms in the time domain ([**_Roy et al., 2017_**](https://doi.org/10.1093/gji/ggw470))
+| Method | Description | Publication |
+| --- | --- | --- |
+| **WS** | stacking of error surfaces, normalized on the minimum/maximum (depending on input) of each single surface | [**_Wolfe & Silver (1998)_**](https://doi.org/10.1029/97JB02023) |
+| **RH** | modified WS method with weight depending on the SNR of each measurement and normalization regarding the available backazimuth directions | [**_Restivo & Helffrich (1999)_**](https://doi.org/10.1046/j.1365-246x.1999.00845.x) |
+| **no weight** | stacking of error surfaces without weighting | [**_Wüstefeld (2007)_**](http://splitting.gm.univ-montp2.fr/) |
+| **SIMW** | simultaneous inversion of multiple waveforms in the time domain | [**_Roy et al. (2017)_**](https://doi.org/10.1093/gji/ggw470) |
 
 ![fig4github](https://user-images.githubusercontent.com/23025878/56716351-6d3d2a80-673a-11e9-8b34-2191c119d780.png)
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Which stacking methods are available?
 
 StackSplit grants easy access to four stacking schemes with which single SWS measurements made with SplitLab can be processed:
 
-| Method | Description | Publication |
-| --- | --- | --- |
-| **WS** | stacking of error surfaces, normalized on the minimum/maximum (depending on input) of each single surface | [**_Wolfe & Silver (1998)_**](https://doi.org/10.1029/97JB02023) |
-| **RH** | modified WS method with weight depending on the SNR of each measurement and normalization regarding the available backazimuth directions | [**_Restivo & Helffrich (1999)_**](https://doi.org/10.1046/j.1365-246x.1999.00845.x) |
-| **no weight** | stacking of error surfaces without weighting | [**_Wüstefeld (2007)_**](http://splitting.gm.univ-montp2.fr/) |
-| **SIMW** | simultaneous inversion of multiple waveforms in the time domain | [**_Roy et al. (2017)_**](https://doi.org/10.1093/gji/ggw470) |
+| Method | Concept | Specification | Publication |
+| --- | --- | --- | --- |
+| **WS** | Stacking of error surfaces | Normalization on the minimum or maximum (depending on input) of each single surface | [**_Wolfe & Silver (1998)_**](https://doi.org/10.1029/97JB02023) |
+| **RH** | Modified WS method | Weighting on the SNR of each measurement; normalization regarding the available backazimuth directions | [**_Restivo & Helffrich (1999)_**](https://doi.org/10.1046/j.1365-246x.1999.00845.x) |
+| **no weight** | Stacking of error surfaces | No weighting | **_Wüstefeld (2007)_** |
+| **SIMW** | Simultaneous inversion of multiple waveforms | Waveform concentration and joint inversion in time domain | [**_Roy et al. (2017)_**](https://doi.org/10.1093/gji/ggw470) |
 
 ![fig4github](https://user-images.githubusercontent.com/23025878/56716351-6d3d2a80-673a-11e9-8b34-2191c119d780.png)
 


### PR DESCRIPTION
Convert the list of stacking methods into a table.

**Preview**:
- list (old): https://github.com/yvonnefroehlich/stacksplit/tree/main?tab=readme-ov-file#which-stacking-methods-are-available
- table (new): https://github.com/yvonnefroehlich/stacksplit/tree/convert-methods2table-readme?tab=readme-ov-file#which-stacking-methods-are-available